### PR TITLE
Allow 'null' in repository.language

### DIFF
--- a/src/Github/PostReceive/Types.hs
+++ b/src/Github/PostReceive/Types.hs
@@ -190,7 +190,7 @@ data Repository = Repository
     , repoSize :: Int
     , repoStargazersCount :: Int
     , repoWatchersCount :: Int
-    , repoLanguage :: Text
+    , repoLanguage :: Maybe Text
     , repoHasIssues :: Bool
     , repoHasDownloads :: Bool
     , repoHasWiki :: Bool


### PR DESCRIPTION
On my first trial on an empty repository (containing only README.md), language field was `null`. 
